### PR TITLE
Temporary workaround for #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,7 @@ Temporary Items
 ### Nim ###
 nimcache/
 
+# Binary
+coco
+
 # End of https://www.gitignore.io/api/macos

--- a/tests/compilation.nim
+++ b/tests/compilation.nim
@@ -7,7 +7,7 @@ suite "Compiles Nim files in coverage mode":
         const basename = "foo"
         const filename = fmt"{basename}.nim"
         const default_cache_folder = get_cache_folder(filename, nimcache, 0)
-        const base_filename = fmt"{default_cache_folder}/coco_{basename}.c"
+        const base_filename = fmt"{default_cache_folder}/@m{filename}.c"
     teardown:
         removeDir(nimcache)
 
@@ -19,23 +19,23 @@ suite "Compiles Nim files in coverage mode":
     test "Each compiled file should have its own folder in nimcache":
         
         compile(fmt"tests/{filename}", nimcache)
-        
+
         check:
-            existsDir(default_cache_folder) == true
-            existsFile(base_filename) == true
-            existsFile(fmt"{base_filename}.gcno") == true
+            existsDir(default_cache_folder)
+            existsFile(base_filename)
+            existsFile(fmt"{base_filename}.gcno")
     
     test "One should be able to pass parameters to the compiler":
 
         compile(fmt"tests/{filename}", nimcache, options = "--hints:off")
         
         check:
-            existsDir(default_cache_folder) == true
-            existsFile(base_filename) == true
-            existsFile(fmt"{base_filename}.gcno") == true
+            existsDir(default_cache_folder)
+            existsFile(base_filename)
+            existsFile(fmt"{base_filename}.gcno")
 
     test "Running a compiled file in coverage mode should generate .gdca files":
         trace(fmt"tests/{filename}")
 
         check:
-            existsFile(fmt"{base_filename}.gcda") == true
+            existsFile(fmt"{base_filename}.gcda")


### PR DESCRIPTION
This is less of a fix and more of a workaround to deal with the `generated_not_to_break_here` line created by the nim compiler. Tested locally with another project (with the compiled binary) and it works. The test still fails however due to it trying to run the binaries the second time after its deleted. Might need more time to dig into it and open a separate PR to fix that instead.